### PR TITLE
feat: email verification via AWS SES and signup address handling

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -92,6 +92,15 @@ jobs:
           SPRING_DATASOURCE_PASSWORD=${{ secrets.SPRING_DATASOURCE_PASSWORD }}
           JWT_SECRET=${{ secrets.JWT_SECRET }}
           JWT_ACCESS_TOKEN_VALIDITY_IN_SECONDS=${{ secrets.JWT_ACCESS_TOKEN_VALIDITY_IN_SECONDS }}
+
+          # --- AWS SES ---
+          AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_SES_REGION=${{ secrets.AWS_SES_REGION }}
+
+          # --- Mail From/Reply-To ---
+          MAIL_FROM=${{ secrets.MAIL_FROM }}
+          MAIL_REPLY_TO=${{ secrets.MAIL_REPLY_TO }}
           EOF
 
       - name: Pull image

--- a/.gitignore
+++ b/.gitignore
@@ -33,9 +33,6 @@ out/
 /nbdist/
 /.nb-gradle/
 
-### VS Code ###
-.vscode/
-
 ### QueryDSL ###
 src/main/generated
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,13 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+      {
+        "type": "java",
+        "name": "Launch Spring Boot (local)",
+        "request": "launch",
+        "mainClass": "mitl.IntoTheHeaven.IntoTheHeavenApplication",
+        "projectName": "backend",
+        "env": { "SPRING_PROFILES_ACTIVE": "local" }
+      }
+    ]
+  }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "java.compile.nullAnalysis.mode": "automatic",
+  "java.configuration.updateBuildConfiguration": "interactive",
+  "java.debug.settings.onBuildFailureProceed": true
+}

--- a/build.gradle
+++ b/build.gradle
@@ -24,12 +24,17 @@ repositories {
 }
 
 dependencies {
+    // AWS SDK BOM for consistent version alignment
+    implementation platform('software.amazon.awssdk:bom:2.25.69')
+
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-cache'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    // AWS SES v2 client
+    implementation 'software.amazon.awssdk:sesv2'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
 //    runtimeOnly 'com.h2database:h2'

--- a/into-the-heaven.erd.json
+++ b/into-the-heaven.erd.json
@@ -4,13 +4,13 @@
   "settings": {
     "width": 20000,
     "height": 20000,
-    "scrollTop": -4949.7155,
-    "scrollLeft": -2681.2112,
-    "zoomLevel": 0.84,
+    "scrollTop": -4425.7888,
+    "scrollLeft": -4363.2124,
+    "zoomLevel": 0.85,
     "show": 431,
     "database": 4,
     "databaseName": "into_the_heaven",
-    "canvasType": "ERD",
+    "canvasType": "@dineug/erd-editor/builtin-schema-sql",
     "language": 32,
     "tableNameCase": 4,
     "columnNameCase": 2,
@@ -38,7 +38,8 @@
       "4vBp6rlXF2dvuWszklmHe",
       "ESkgqEGCwEvFi1SKNfDe2",
       "QGaydjKzVJlvi2Ko-MuX0",
-      "cu5zs7tHl9_EJYt_l_Mlf"
+      "cu5zs7tHl9_EJYt_l_Mlf",
+      "K26WzN3oqI1cydc0nORcZ"
     ],
     "relationshipIds": [
       "0ZCyf2_iOJc1HvE8KlKJD",
@@ -405,8 +406,45 @@
           "color": "#FF9800"
         },
         "meta": {
-          "updateAt": 1750815575212,
+          "updateAt": 1755059047456,
           "createAt": 1731379725495
+        }
+      },
+      "K26WzN3oqI1cydc0nORcZ": {
+        "id": "K26WzN3oqI1cydc0nORcZ",
+        "name": "verification",
+        "comment": "검증",
+        "columnIds": [
+          "q7BAK-Rsc1GY-ruCC5yG3",
+          "XdNhyMKDNmrVMYhLL8LTM",
+          "lWEgSRHxmAVB8pn09qQmc",
+          "wSK1sJArviW4DrAeLqwfN",
+          "0sES2Qtxyf1t8YHj3gv_C",
+          "6Yd0Qh0paY0QiY8RwPhbh",
+          "BjtOhCckS56y2lA-xQeW9"
+        ],
+        "seqColumnIds": [
+          "q7BAK-Rsc1GY-ruCC5yG3",
+          "XdNhyMKDNmrVMYhLL8LTM",
+          "nhs_cyDe3Du-QnIByq7x8",
+          "MIsB18fxKKS5_KeBItZ1H",
+          "lWEgSRHxmAVB8pn09qQmc",
+          "wSK1sJArviW4DrAeLqwfN",
+          "0sES2Qtxyf1t8YHj3gv_C",
+          "6Yd0Qh0paY0QiY8RwPhbh",
+          "BjtOhCckS56y2lA-xQeW9"
+        ],
+        "ui": {
+          "x": 3632.4859,
+          "y": 3775.8517,
+          "zIndex": 962,
+          "widthName": 65,
+          "widthComment": 60,
+          "color": "#D600FF"
+        },
+        "meta": {
+          "updateAt": 1755060251558,
+          "createAt": 1755059041294
         }
       }
     },
@@ -2549,6 +2587,186 @@
         "meta": {
           "updateAt": 1752466646631,
           "createAt": 1752466633783
+        }
+      },
+      "q7BAK-Rsc1GY-ruCC5yG3": {
+        "id": "q7BAK-Rsc1GY-ruCC5yG3",
+        "tableId": "K26WzN3oqI1cydc0nORcZ",
+        "name": "id",
+        "comment": "검증 아이디",
+        "dataType": "CHAR(36)",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1755059123277,
+          "createAt": 1755059097725
+        }
+      },
+      "XdNhyMKDNmrVMYhLL8LTM": {
+        "id": "XdNhyMKDNmrVMYhLL8LTM",
+        "tableId": "K26WzN3oqI1cydc0nORcZ",
+        "name": "type",
+        "comment": "검증 대상",
+        "dataType": "VARCHAR(20)",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 83,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1755060177822,
+          "createAt": 1755059157757
+        }
+      },
+      "nhs_cyDe3Du-QnIByq7x8": {
+        "id": "nhs_cyDe3Du-QnIByq7x8",
+        "tableId": "K26WzN3oqI1cydc0nORcZ",
+        "name": "type",
+        "comment": "검증 타입",
+        "dataType": "VARCHAR(20)",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 83,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1755059365162,
+          "createAt": 1755059160223
+        }
+      },
+      "0sES2Qtxyf1t8YHj3gv_C": {
+        "id": "0sES2Qtxyf1t8YHj3gv_C",
+        "tableId": "K26WzN3oqI1cydc0nORcZ",
+        "name": "created_at",
+        "comment": "생성일시",
+        "dataType": "DATETIME(6)",
+        "default": "CURRENT_TIMESTAMP(6)",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 63,
+          "widthComment": 60,
+          "widthDataType": 77,
+          "widthDefault": 150
+        },
+        "meta": {
+          "updateAt": 1755059162282,
+          "createAt": 1755059160387
+        }
+      },
+      "6Yd0Qh0paY0QiY8RwPhbh": {
+        "id": "6Yd0Qh0paY0QiY8RwPhbh",
+        "tableId": "K26WzN3oqI1cydc0nORcZ",
+        "name": "updated_at",
+        "comment": "수정일시",
+        "dataType": "DATETIME(6)",
+        "default": "CURRENT_TIMESTAMP(6)",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 67,
+          "widthComment": 60,
+          "widthDataType": 77,
+          "widthDefault": 150
+        },
+        "meta": {
+          "updateAt": 1755059162282,
+          "createAt": 1755059160534
+        }
+      },
+      "BjtOhCckS56y2lA-xQeW9": {
+        "id": "BjtOhCckS56y2lA-xQeW9",
+        "tableId": "K26WzN3oqI1cydc0nORcZ",
+        "name": "deleted_at",
+        "comment": "삭제일시",
+        "dataType": "DATETIME(6)",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 62,
+          "widthComment": 60,
+          "widthDataType": 77,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1755059162282,
+          "createAt": 1755059160670
+        }
+      },
+      "MIsB18fxKKS5_KeBItZ1H": {
+        "id": "MIsB18fxKKS5_KeBItZ1H",
+        "tableId": "K26WzN3oqI1cydc0nORcZ",
+        "name": "type",
+        "comment": "검증 타입",
+        "dataType": "VARCHAR(20)",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 83,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1755059462426,
+          "createAt": 1755059380128
+        }
+      },
+      "wSK1sJArviW4DrAeLqwfN": {
+        "id": "wSK1sJArviW4DrAeLqwfN",
+        "tableId": "K26WzN3oqI1cydc0nORcZ",
+        "name": "code",
+        "comment": "검증 코드",
+        "dataType": "VARCHAR(20)",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 83,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1755060299433,
+          "createAt": 1755059468185
+        }
+      },
+      "lWEgSRHxmAVB8pn09qQmc": {
+        "id": "lWEgSRHxmAVB8pn09qQmc",
+        "tableId": "K26WzN3oqI1cydc0nORcZ",
+        "name": "type_value",
+        "comment": "검증 대상 값",
+        "dataType": "VARCHAR(100)",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 64,
+          "widthComment": 61,
+          "widthDataType": 89,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1755060090119,
+          "createAt": 1755060048018
         }
       }
     },

--- a/src/main/java/mitl/IntoTheHeaven/adapter/in/web/controller/AuthController.java
+++ b/src/main/java/mitl/IntoTheHeaven/adapter/in/web/controller/AuthController.java
@@ -2,6 +2,9 @@ package mitl.IntoTheHeaven.adapter.in.web.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.Parameter;
+import mitl.IntoTheHeaven.adapter.in.web.dto.member.AvailabilityResponse;
+import mitl.IntoTheHeaven.application.port.in.query.MemberQueryUseCase;
 import lombok.RequiredArgsConstructor;
 import mitl.IntoTheHeaven.adapter.in.web.dto.auth.LoginRequest;
 import mitl.IntoTheHeaven.adapter.in.web.dto.auth.LoginResponse;
@@ -9,30 +12,57 @@ import mitl.IntoTheHeaven.adapter.in.web.dto.member.SignUpRequest;
 import mitl.IntoTheHeaven.adapter.in.web.dto.member.SignUpResponse;
 import mitl.IntoTheHeaven.application.port.in.command.LoginUseCase;
 import mitl.IntoTheHeaven.application.port.in.command.MemberCommandUseCase;
+import mitl.IntoTheHeaven.application.port.in.command.VerificationCommandUseCase;
+import mitl.IntoTheHeaven.adapter.in.web.dto.auth.SendEmailVerificationRequest;
+import mitl.IntoTheHeaven.adapter.in.web.dto.auth.ConfirmEmailVerificationRequest;
 import mitl.IntoTheHeaven.domain.model.Member;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 
 @Tag(name = "Auth", description = "APIs for Authentication")
 @RestController
 @RequestMapping("/auth")
 @RequiredArgsConstructor
+@Validated
 public class AuthController {
 
     private final LoginUseCase loginUseCase;
     private final MemberCommandUseCase memberCommandUseCase;
+    private final MemberQueryUseCase memberQueryUseCase;
+    private final VerificationCommandUseCase verificationCommandUseCase;
 
     @Operation(summary = "User Login", description = "Logs in a user with email and password.")
     @PostMapping("/login")
     public ResponseEntity<LoginResponse> login(@RequestBody @Valid LoginRequest loginRequest) {
         LoginResponse response = loginUseCase.login(loginRequest);
         return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "Send Email Verification Code", description = "Sends a verification code to the specified email.")
+    @PostMapping("/verification/email")
+    public ResponseEntity<Void> sendEmailVerification(@RequestBody @Valid SendEmailVerificationRequest request) {
+        verificationCommandUseCase.sendEmailVerificationCode(request.getEmail());
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "Confirm Email Verification Code", description = "Confirms the verification code for the specified email.")
+    @PostMapping("/verification/email/confirm")
+    public ResponseEntity<?> confirmEmailVerification(@RequestBody @Valid ConfirmEmailVerificationRequest request) {
+        boolean ok = verificationCommandUseCase.confirmEmailVerificationCode(request.getEmail(), request.getCode());
+        if (ok) {
+            return ResponseEntity.ok().build();
+        }
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Invalid verification code");
     }
 
     @Operation(summary = "User Signup", description = "Registers a new user.")
@@ -44,5 +74,29 @@ public class AuthController {
                 .message("User signed up successfully.")
                 .build();
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @Operation(summary = "Check Phone Availability", description = "Checks if a phone number is available for signup.")
+    @org.springframework.web.bind.annotation.GetMapping("/availability/phone")
+    public ResponseEntity<AvailabilityResponse> isPhoneAvailable(
+            @Parameter(description = "Phone number to check", required = true)
+            @org.springframework.web.bind.annotation.RequestParam("value")
+            @NotBlank(message = "Phone number must not be blank")
+            @Pattern(regexp = "^\\d{9,15}$", message = "Phone number must be 9-15 digits") String phone
+    ) {
+        boolean available = memberQueryUseCase.isPhoneAvailable(phone);
+        return ResponseEntity.ok(AvailabilityResponse.of(available));
+    }
+
+    @Operation(summary = "Check Email Availability", description = "Checks if an email is available for signup.")
+    @org.springframework.web.bind.annotation.GetMapping("/availability/email")
+    public ResponseEntity<AvailabilityResponse> isEmailAvailable(
+            @Parameter(description = "Email to check", required = true)
+            @org.springframework.web.bind.annotation.RequestParam("value")
+            @NotBlank(message = "Email must not be blank")
+            @Email(message = "Invalid email format") String email
+    ) {
+        boolean available = memberQueryUseCase.isEmailAvailable(email);
+        return ResponseEntity.ok(AvailabilityResponse.of(available));
     }
 } 

--- a/src/main/java/mitl/IntoTheHeaven/adapter/in/web/controller/MemberController.java
+++ b/src/main/java/mitl/IntoTheHeaven/adapter/in/web/controller/MemberController.java
@@ -31,4 +31,5 @@ public class MemberController {
         MeResponse response = MeResponse.from(member);
         return ResponseEntity.ok(response);
     }
+
 } 

--- a/src/main/java/mitl/IntoTheHeaven/adapter/in/web/dto/auth/ConfirmEmailVerificationRequest.java
+++ b/src/main/java/mitl/IntoTheHeaven/adapter/in/web/dto/auth/ConfirmEmailVerificationRequest.java
@@ -1,0 +1,17 @@
+package mitl.IntoTheHeaven.adapter.in.web.dto.auth;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class ConfirmEmailVerificationRequest {
+    @NotBlank
+    @Email
+    private String email;
+
+    @NotBlank
+    private String code;
+}
+
+

--- a/src/main/java/mitl/IntoTheHeaven/adapter/in/web/dto/auth/SendEmailVerificationRequest.java
+++ b/src/main/java/mitl/IntoTheHeaven/adapter/in/web/dto/auth/SendEmailVerificationRequest.java
@@ -1,0 +1,14 @@
+package mitl.IntoTheHeaven.adapter.in.web.dto.auth;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class SendEmailVerificationRequest {
+    @NotBlank
+    @Email
+    private String email;
+}
+
+

--- a/src/main/java/mitl/IntoTheHeaven/adapter/in/web/dto/member/AvailabilityResponse.java
+++ b/src/main/java/mitl/IntoTheHeaven/adapter/in/web/dto/member/AvailabilityResponse.java
@@ -1,0 +1,18 @@
+package mitl.IntoTheHeaven.adapter.in.web.dto.member;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class AvailabilityResponse {
+    private final boolean available;
+
+    public static AvailabilityResponse of(boolean available) {
+        return AvailabilityResponse.builder().available(available).build();
+    }
+}
+
+

--- a/src/main/java/mitl/IntoTheHeaven/adapter/in/web/dto/member/SignUpRequest.java
+++ b/src/main/java/mitl/IntoTheHeaven/adapter/in/web/dto/member/SignUpRequest.java
@@ -38,8 +38,6 @@ public class SignUpRequest {
     private String phone;
     
     private String address;
-    
-    private String description;
 
     public SignUpCommand toCommand() {
         return SignUpCommand.builder()
@@ -50,7 +48,6 @@ public class SignUpRequest {
                 .sex(sex)
                 .phone(phone)
                 .address(address)
-                .description(description)
                 .build();
     }
 } 

--- a/src/main/java/mitl/IntoTheHeaven/adapter/out/email/SesEmailAdapter.java
+++ b/src/main/java/mitl/IntoTheHeaven/adapter/out/email/SesEmailAdapter.java
@@ -1,0 +1,65 @@
+package mitl.IntoTheHeaven.adapter.out.email;
+
+import mitl.IntoTheHeaven.application.port.out.EmailPort;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.sesv2.SesV2Client;
+import software.amazon.awssdk.services.sesv2.model.Body;
+import software.amazon.awssdk.services.sesv2.model.Content;
+import software.amazon.awssdk.services.sesv2.model.Destination;
+import software.amazon.awssdk.services.sesv2.model.EmailContent;
+import software.amazon.awssdk.services.sesv2.model.Message;
+import software.amazon.awssdk.services.sesv2.model.SendEmailRequest;
+
+/**
+ * SES-based implementation of EmailPort.
+ */
+@Component
+public class SesEmailAdapter implements EmailPort {
+
+    private final SesV2Client sesClient;
+    private final String fromAddress;
+    private final String replyToAddress;
+
+    public SesEmailAdapter(
+            SesV2Client sesClient,
+            @Value("${mail.from}") String fromAddress,
+            @Value("${mail.reply-to:}") String replyToAddress
+    ) {
+        this.sesClient = sesClient;
+        this.fromAddress = fromAddress;
+        this.replyToAddress = replyToAddress;
+    }
+
+    @Override
+    public void sendTextEmail(String toAddress, String subject, String bodyText) {
+        Destination destination = Destination.builder()
+                .toAddresses(toAddress)
+                .build();
+
+        Message message = Message.builder()
+                .subject(Content.builder().data(subject).charset("UTF-8").build())
+                .body(Body.builder()
+                        .text(Content.builder().data(bodyText).charset("UTF-8").build())
+                        .build())
+                .build();
+
+        EmailContent emailContent = EmailContent.builder()
+                .simple(message)
+                .build();
+
+        SendEmailRequest.Builder requestBuilder = SendEmailRequest.builder()
+                .fromEmailAddress(fromAddress)
+                .destination(destination)
+                .content(emailContent);
+
+        if (replyToAddress != null && !replyToAddress.isBlank()) {
+            requestBuilder = requestBuilder.replyToAddresses(replyToAddress);
+        }
+
+        sesClient.sendEmail(requestBuilder.build());
+    }
+}
+
+
+

--- a/src/main/java/mitl/IntoTheHeaven/adapter/out/persistence/MemberPersistenceAdapter.java
+++ b/src/main/java/mitl/IntoTheHeaven/adapter/out/persistence/MemberPersistenceAdapter.java
@@ -1,7 +1,6 @@
 package mitl.IntoTheHeaven.adapter.out.persistence;
 
 import lombok.RequiredArgsConstructor;
-import mitl.IntoTheHeaven.adapter.out.persistence.entity.GroupMemberJpaEntity;
 import mitl.IntoTheHeaven.adapter.out.persistence.entity.MemberJpaEntity;
 import mitl.IntoTheHeaven.adapter.out.persistence.mapper.MemberPersistenceMapper;
 import mitl.IntoTheHeaven.adapter.out.persistence.repository.MemberJpaRepository;
@@ -54,6 +53,12 @@ public class MemberPersistenceAdapter implements MemberPort {
   @Override
   public Optional<Member> findByEmail(String email) {
     return memberJpaRepository.findByEmail(email)
+            .map(memberPersistenceMapper::toDomain);
+  }
+
+  @Override
+  public Optional<Member> findByPhone(String phone) {
+    return memberJpaRepository.findByPhone(phone)
             .map(memberPersistenceMapper::toDomain);
   }
 } 

--- a/src/main/java/mitl/IntoTheHeaven/adapter/out/persistence/entity/VerificationJpaEntity.java
+++ b/src/main/java/mitl/IntoTheHeaven/adapter/out/persistence/entity/VerificationJpaEntity.java
@@ -1,0 +1,34 @@
+package mitl.IntoTheHeaven.adapter.out.persistence.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import mitl.IntoTheHeaven.domain.enums.VerificationType;
+import mitl.IntoTheHeaven.global.common.BaseEntity;
+import org.hibernate.annotations.SQLRestriction;
+
+@Entity
+@Table(name = "verification")
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@SQLRestriction("deleted_at is null")
+public class VerificationJpaEntity extends BaseEntity {
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", length = 20, nullable = false)
+    private VerificationType type;
+
+    @Column(name = "type_value", length = 100, nullable = false)
+    private String typeValue;
+
+    @Column(name = "code", length = 10, nullable = false)
+    private String code;
+}
+
+

--- a/src/main/java/mitl/IntoTheHeaven/adapter/out/persistence/mapper/MemberPersistenceMapper.java
+++ b/src/main/java/mitl/IntoTheHeaven/adapter/out/persistence/mapper/MemberPersistenceMapper.java
@@ -27,7 +27,6 @@ public class MemberPersistenceMapper {
                 .phone(entity.getPhone())
                 .profileUrl(entity.getProfileUrl())
                 .address(entity.getAddress())
-                .description(entity.getDescription())
                 .createdAt(entity.getCreatedAt())
                 .updatedAt(entity.getUpdatedAt())
                 .deletedAt(entity.getDeletedAt())
@@ -48,7 +47,6 @@ public class MemberPersistenceMapper {
                 .phone(domain.getPhone())
                 .profileUrl(domain.getProfileUrl())
                 .address(domain.getAddress())
-                .description(domain.getDescription())
                 .build();
     }
 

--- a/src/main/java/mitl/IntoTheHeaven/adapter/out/persistence/repository/MemberJpaRepository.java
+++ b/src/main/java/mitl/IntoTheHeaven/adapter/out/persistence/repository/MemberJpaRepository.java
@@ -11,6 +11,8 @@ import java.util.UUID;
 public interface MemberJpaRepository extends JpaRepository<MemberJpaEntity, UUID> {
     Optional<MemberJpaEntity> findByEmail(String email);
 
+    Optional<MemberJpaEntity> findByPhone(String phone);
+
     @EntityGraph(attributePaths = {"groupMembers", "groupMembers.group"})
     Optional<MemberJpaEntity> findWithGroupsById(UUID memberId);
 

--- a/src/main/java/mitl/IntoTheHeaven/adapter/out/persistence/repository/VerificationJpaRepository.java
+++ b/src/main/java/mitl/IntoTheHeaven/adapter/out/persistence/repository/VerificationJpaRepository.java
@@ -1,0 +1,14 @@
+package mitl.IntoTheHeaven.adapter.out.persistence.repository;
+
+import mitl.IntoTheHeaven.adapter.out.persistence.entity.VerificationJpaEntity;
+import mitl.IntoTheHeaven.domain.enums.VerificationType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface VerificationJpaRepository extends JpaRepository<VerificationJpaEntity, UUID> {
+    Optional<VerificationJpaEntity> findTopByTypeAndTypeValueOrderByCreatedAtDesc(VerificationType type, String typeValue);
+}
+
+

--- a/src/main/java/mitl/IntoTheHeaven/application/port/in/command/VerificationCommandUseCase.java
+++ b/src/main/java/mitl/IntoTheHeaven/application/port/in/command/VerificationCommandUseCase.java
@@ -1,0 +1,10 @@
+package mitl.IntoTheHeaven.application.port.in.command;
+
+public interface VerificationCommandUseCase {
+
+    void sendEmailVerificationCode(String email);
+
+    boolean confirmEmailVerificationCode(String email, String code);
+}
+
+

--- a/src/main/java/mitl/IntoTheHeaven/application/port/in/command/dto/SignUpCommand.java
+++ b/src/main/java/mitl/IntoTheHeaven/application/port/in/command/dto/SignUpCommand.java
@@ -21,5 +21,4 @@ public class SignUpCommand {
     private String sex;
     private String phone;
     private String address;
-    private String description;
 } 

--- a/src/main/java/mitl/IntoTheHeaven/application/port/in/query/MemberQueryUseCase.java
+++ b/src/main/java/mitl/IntoTheHeaven/application/port/in/query/MemberQueryUseCase.java
@@ -9,4 +9,18 @@ import java.util.UUID;
 public interface MemberQueryUseCase {
     Member getMemberById(MemberId memberId);
     List<Member> getMembersByGroupId(UUID groupId);
+
+    /**
+     * Checks availability of a phone number for signup.
+     * @param phone phone number string
+     * @return true if the phone number is not used yet
+     */
+    boolean isPhoneAvailable(String phone);
+
+    /**
+     * Checks availability of an email for signup.
+     * @param email email string
+     * @return true if the email is not used yet
+     */
+    boolean isEmailAvailable(String email);
 } 

--- a/src/main/java/mitl/IntoTheHeaven/application/port/out/EmailPort.java
+++ b/src/main/java/mitl/IntoTheHeaven/application/port/out/EmailPort.java
@@ -1,0 +1,18 @@
+package mitl.IntoTheHeaven.application.port.out;
+
+/**
+ * Outbound port for sending emails.
+ */
+public interface EmailPort {
+
+    /**
+     * Sends a simple text email.
+     *
+     * @param toAddress recipient email address
+     * @param subject   email subject
+     * @param bodyText  plain text body
+     */
+    void sendTextEmail(String toAddress, String subject, String bodyText);
+}
+
+

--- a/src/main/java/mitl/IntoTheHeaven/application/port/out/MemberPort.java
+++ b/src/main/java/mitl/IntoTheHeaven/application/port/out/MemberPort.java
@@ -18,4 +18,6 @@ public interface MemberPort {
   Member save(Member member);
 
   Optional<Member> findByEmail(String email);
+
+  Optional<Member> findByPhone(String phone);
 } 

--- a/src/main/java/mitl/IntoTheHeaven/application/service/command/EmailVerificationService.java
+++ b/src/main/java/mitl/IntoTheHeaven/application/service/command/EmailVerificationService.java
@@ -1,0 +1,83 @@
+package mitl.IntoTheHeaven.application.service.command;
+
+import lombok.RequiredArgsConstructor;
+import mitl.IntoTheHeaven.adapter.out.persistence.entity.VerificationJpaEntity;
+import mitl.IntoTheHeaven.adapter.out.persistence.repository.VerificationJpaRepository;
+import mitl.IntoTheHeaven.application.port.in.command.VerificationCommandUseCase;
+import mitl.IntoTheHeaven.application.port.out.EmailPort;
+import mitl.IntoTheHeaven.domain.enums.VerificationType;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.security.SecureRandom;
+import java.util.Locale;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class EmailVerificationService implements VerificationCommandUseCase {
+
+    private final EmailPort emailPort;
+    private final VerificationJpaRepository verificationRepository;
+
+    private static final String CODE_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+    private static final int CODE_LENGTH = 10;
+
+    @Override
+    @Transactional
+    public void sendEmailVerificationCode(String email) {
+        String code = generateRandomCode(CODE_LENGTH);
+
+        VerificationJpaEntity entity = VerificationJpaEntity.builder()
+                .id(UUID.randomUUID())
+                .type(VerificationType.EMAIL)
+                .typeValue(email.toLowerCase(Locale.ROOT))
+                .code(code)
+                .build();
+
+        verificationRepository.save(entity);
+
+        String subject = "Your verification code";
+        String body = "Your verification code is: " + code + "\nIt expires in 10 minutes.";
+        emailPort.sendTextEmail(email, subject, body);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public boolean confirmEmailVerificationCode(String email, String code) {
+        // Find the latest verification entity for the given email
+        VerificationJpaEntity entity = verificationRepository
+                .findTopByTypeAndTypeValueOrderByCreatedAtDesc(VerificationType.EMAIL, email.toLowerCase(Locale.ROOT))
+                .orElse(null);
+
+        if (entity == null) {
+            return false;
+        }
+
+        // Check if code matches
+        if (!entity.getCode().equals(code)) {
+            return false;
+        }
+
+        // Check if createdAt is within 1 hour
+        // Assume getCreatedAt() returns a java.time.LocalDateTime
+        java.time.LocalDateTime createdAt = entity.getCreatedAt();
+        java.time.LocalDateTime now = java.time.LocalDateTime.now();
+        java.time.Duration duration = java.time.Duration.between(createdAt, now);
+
+        // 1 hour = 60 minutes
+        return duration.toMinutes() <= 60;
+    }
+
+    private String generateRandomCode(int length) {
+        SecureRandom random = new SecureRandom();
+        StringBuilder builder = new StringBuilder(length);
+        for (int i = 0; i < length; i++) {
+            int idx = random.nextInt(CODE_ALPHABET.length());
+            builder.append(CODE_ALPHABET.charAt(idx));
+        }
+        return builder.toString();
+    }
+}
+
+

--- a/src/main/java/mitl/IntoTheHeaven/application/service/command/MemberCommandService.java
+++ b/src/main/java/mitl/IntoTheHeaven/application/service/command/MemberCommandService.java
@@ -32,7 +32,6 @@ public class MemberCommandService implements MemberCommandUseCase {
                 .birthday(command.getBirthdate())
                 .phone(command.getPhone())
                 .address(command.getAddress())
-                .description(command.getDescription())
                 .build();
 
         return memberPort.save(member);

--- a/src/main/java/mitl/IntoTheHeaven/application/service/query/MemberQueryService.java
+++ b/src/main/java/mitl/IntoTheHeaven/application/service/query/MemberQueryService.java
@@ -28,4 +28,14 @@ public class MemberQueryService implements MemberQueryUseCase {
   public List<Member> getMembersByGroupId(UUID groupId) {
     return memberPort.findMembersByGroupId(groupId);
   }
+
+  @Override
+  public boolean isPhoneAvailable(String phone) {
+    return memberPort.findByPhone(phone).isEmpty();
+  }
+
+  @Override
+  public boolean isEmailAvailable(String email) {
+    return memberPort.findByEmail(email).isEmpty();
+  }
 } 

--- a/src/main/java/mitl/IntoTheHeaven/domain/enums/VerificationType.java
+++ b/src/main/java/mitl/IntoTheHeaven/domain/enums/VerificationType.java
@@ -1,0 +1,8 @@
+package mitl.IntoTheHeaven.domain.enums;
+
+public enum VerificationType {
+    EMAIL,
+    PHONE
+}
+
+

--- a/src/main/java/mitl/IntoTheHeaven/domain/model/Member.java
+++ b/src/main/java/mitl/IntoTheHeaven/domain/model/Member.java
@@ -19,7 +19,6 @@ public class Member extends AggregateRoot<Member, MemberId> {
     private final String phone;
     private final String profileUrl;
     private final String address;
-    private final String description;
     private final LocalDateTime createdAt;
     private final LocalDateTime updatedAt;
     private final LocalDateTime deletedAt;

--- a/src/main/java/mitl/IntoTheHeaven/global/config/SesConfig.java
+++ b/src/main/java/mitl/IntoTheHeaven/global/config/SesConfig.java
@@ -1,0 +1,50 @@
+package mitl.IntoTheHeaven.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sesv2.SesV2Client;
+
+/**
+ * Configures AWS SES v2 client.
+ * Region is provided via application properties.
+ * Credentials resolution:
+ *  - If aws.access-key-id and aws.secret-access-key are provided (non-blank), use them via StaticCredentialsProvider
+ *  - Otherwise, fall back to DefaultCredentialsProvider (env vars, system props, ~/.aws, IAM role, etc.)
+ */
+@Configuration
+public class SesConfig {
+
+    @Value("${aws.ses.region}")
+    private String awsSesRegion;
+
+    @Value("${aws.access-key-id:}")
+    private String accessKeyId;
+
+    @Value("${aws.secret-access-key:}")
+    private String secretAccessKey;
+
+    @Bean
+    public SesV2Client sesV2Client() {
+        Region region = Region.of(awsSesRegion);
+        AwsCredentialsProvider credentialsProvider = resolveCredentialsProvider();
+        return SesV2Client.builder()
+                .region(region)
+                .credentialsProvider(credentialsProvider)
+                .build();
+    }
+
+    private AwsCredentialsProvider resolveCredentialsProvider() {
+        if (accessKeyId != null && !accessKeyId.isBlank() && secretAccessKey != null && !secretAccessKey.isBlank()) {
+            return StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKeyId, secretAccessKey));
+        }
+        return DefaultCredentialsProvider.create();
+    }
+}
+
+

--- a/src/main/resources/application-local-example.properties
+++ b/src/main/resources/application-local-example.properties
@@ -36,3 +36,10 @@ spring.devtools.restart.exclude=
 spring.jpa.properties.hibernate.jdbc.time_zone=
 # JSON serialization timezone (present as KST)
 spring.jackson.time-zone=
+
+# === AWS SES (Email) ===
+aws.access-key-id=
+aws.secret-access-key=
+aws.ses.region=
+mail.from=
+mail.reply-to=

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,16 +1,29 @@
-spring.application.name=IntoTheHeaven
+# Minimal properties for test context
 
-# H2 Database Settings for Test
+# Use in-memory H2 database to avoid external MySQL dependency during tests
 spring.datasource.driver-class-name=org.h2.Driver
-spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.url=jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
 spring.datasource.username=sa
 spring.datasource.password=
-spring.jpa.hibernate.ddl-auto=create-drop
-spring.jpa.properties.hibernate.format_sql=true
-
-# 스키마 초기화 비활성화 (JPA DDL 자동 생성 사용)
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.jpa.show-sql=false
+spring.jpa.hibernate.ddl-auto=none
+spring.jpa.properties.hibernate.format_sql=false
+spring.jpa.open-in-view=false
 spring.sql.init.mode=never
+spring.jpa.properties.hibernate.jdbc.use_get_generated_keys=true
+spring.jpa.properties.hibernate.order_inserts=true
+spring.jpa.properties.hibernate.order_updates=true
+spring.jpa.properties.hibernate.jdbc.batch_size=100
+spring.jpa.properties.hibernate.jdbc.time_zone=UTC
+spring.jpa.properties.hibernate.default_batch_fetch_size=1000
 
-# JWT Settings for Test
-jwt.secret=OThlYjM0MjMtYjQ1Mi00ZGNhLTg2YjgtN2YyYjQ1NjE3YjM0OThlYjM0MjMtYjQ1Mi00ZGNhLTg2YjgtN2YyYjQ1NjE3YjM0Cg==
-jwt.access-token-validity-in-seconds=86400
+# SES/Email dummy values
+aws.ses.region=ap-northeast-2
+mail.from=no-reply@example.com
+mail.reply-to=
+
+# JWT dummy values (Base64; >= 256-bit)
+jwt.secret=MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDE=
+jwt.access-token-validity-in-seconds=3600
+


### PR DESCRIPTION
- add EmailPort and SES outbound adapter
  - add SesV2 client config with fallback credentials (properties > default chain)
  - implement SesEmailAdapter using mail.from/mail.reply-to
- introduce email verification flow
  - add endpoints: POST /auth/verification/email, /auth/verification/email/confirm
  - add DTOs: SendEmailVerificationRequest, ConfirmEmailVerificationRequest
  - add VerificationType enum and JPA entity/repository for verification
  - add EmailVerificationService (random 10-char code, persist, send, confirm)
- wire controller to new verification use case
- signup enhancements
  - accept and persist address field
  - remove description from sign-up DTO/command/domain/mapper
- build/test
  - add AWS SDK (sesv2) and BOM in build.gradle
  - add test application.properties with H2 and JWT dummy configs
- CI/CD
  - prepare env injection placeholders for AWS SES and mail settings (cicd.yml)